### PR TITLE
fix: url(a tag)が長い場合折り返す

### DIFF
--- a/src/lib/components/Note/Content.svelte
+++ b/src/lib/components/Note/Content.svelte
@@ -75,7 +75,7 @@
 									{/if}
 								{:else if tag === 'a'}
 									<a
-										class="text-blue-600 visited:text-purple-600"
+										class="text-blue-600 visited:text-purple-600 break-words"
 										{href}
 										target="_blank"
 										rel="noopener noreferrer"


### PR DESCRIPTION
close #191