### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 name: lint
 on: push
+permissions:
+  contents: read
 
 jobs:
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/mouse484/astraea/security/code-scanning/2](https://github.com/mouse484/astraea/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs linting tasks, it does not require write permissions. The minimal permissions required are `contents: read`, which allows the workflow to read repository contents without granting write access. This block should be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to specify repository access permissions for the lint job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->