### PR TITLE
content warning 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-popover": "^1.1.14",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-tooltip": "^1.2.7",
         "@tailwindcss/vite": "^4.1.11",
         "@tanstack/query-async-storage-persister": "^5.81.5",
@@ -2600,6 +2601,31 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.9.tgz",
+      "integrity": "sha512-ZoFkBBz9zv9GWer7wIjvdRxmh2wyc2oKWw6C6CseWd6/yq1DK/l5lJ+wnsmFwJZbBYqr02mrf8A2q/CVCuM3ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-popover": "^1.1.14",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tailwindcss/vite": "^4.1.11",
     "@tanstack/query-async-storage-persister": "^5.81.5",

--- a/src/components/text-note/TextNote.tsx
+++ b/src/components/text-note/TextNote.tsx
@@ -2,7 +2,8 @@ import type { TextNoteEventSchema } from '@/lib/nostr/kinds/1'
 import { useQuery } from '@tanstack/react-query'
 import { Link, useNavigate } from '@tanstack/react-router'
 import { format, fromUnixTime } from 'date-fns'
-import { Ellipsis } from 'lucide-react'
+import { Ellipsis, Eye } from 'lucide-react'
+import { useState } from 'react'
 import { metadataQuery } from '@/lib/nostr/kinds/0'
 import { createEvent, createPubkey } from '@/lib/nostr/nip19'
 import useNostr from '@/lib/nostr/use-nostr'
@@ -22,6 +23,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from '@/shadcn-ui/components/ui/dropdown-menu'
+import { Skeleton } from '@/shadcn-ui/components/ui/skeleton'
 import ProfileIcon from '../profile/ProfileIcon'
 import UserName from '../profile/UserName'
 import Footer from './footer/Footer'
@@ -41,6 +43,10 @@ export default function TextNote({ event, withReplies }: Props) {
   const displayName = metadata?.content.display_name
     || metadata?.content.name
     || pubkey.encoded.slice(0, 8)
+
+  const [contentWarning, setContentWarning] = useState(
+    event.tags.find(tag => tag[0] === 'content-warning'),
+  )
 
   return (
     <>
@@ -100,7 +106,35 @@ export default function TextNote({ event, withReplies }: Props) {
               </CardAction>
             </CardHeader>
             <CardContent className="p-0 pt-2">
-              <p className="inline cursor-text select-text">{event.content}</p>
+              {contentWarning
+                ? (
+                    <div className="relative">
+                      <Skeleton className="h-20" />
+                      <Button
+                        className={`
+                          absolute top-1/2 left-1/2 -translate-x-1/2
+                          -translate-y-1/2
+                        `}
+                        variant="outline"
+                        onClick={() => {
+                          setContentWarning(undefined)
+                        }}
+                      >
+                        <Eye />
+                        Show
+                        {contentWarning[1] && (
+                          <span className="text-muted-foreground text-xs">
+                            (
+                            {contentWarning[1]}
+                            )
+                          </span>
+                        )}
+                      </Button>
+                    </div>
+                  )
+                : (
+                    <p className="inline cursor-text select-text">{event.content}</p>
+                  )}
             </CardContent>
             <CardFooter className="p-0 pt-3">
               <Footer event={event} />

--- a/src/components/text-note/footer/Reply.tsx
+++ b/src/components/text-note/footer/Reply.tsx
@@ -8,7 +8,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/shadcn-ui/components/ui/collapsible'
-import TextNoteForm from '../TextNoteForm'
+import TextNoteForm from '../form/TextNoteForm'
 
 interface Props {
   event: typeof TextNoteEventSchema.Type

--- a/src/components/text-note/form/ContentWarningForm.tsx
+++ b/src/components/text-note/form/ContentWarningForm.tsx
@@ -57,10 +57,10 @@ export default function ContentWarningForm({
           </DialogTitle>
         </DialogHeader>
         <div>
-          <Label htmlFor="content-warining-reason">Reason (optional)</Label>
+          <Label htmlFor="content-warning-reason">Reason (optional)</Label>
           <Input
-            id="content-warining-reason"
-            placeholder="senstive, violence..."
+            id="content-warning-reason"
+            placeholder="sensitive, violence..."
             value={reason}
             onChange={event => setReason(event.target.value)}
           />

--- a/src/components/text-note/form/ContentWarningForm.tsx
+++ b/src/components/text-note/form/ContentWarningForm.tsx
@@ -1,0 +1,93 @@
+import { EyeOff } from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '@/shadcn-ui/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/shadcn-ui/components/ui/dialog'
+import { Input } from '@/shadcn-ui/components/ui/input'
+import { Label } from '@/shadcn-ui/components/ui/label'
+import { Toggle } from '@/shadcn-ui/components/ui/toggle'
+
+interface Props {
+  value: false | true | string
+  onChange: (value: false | true | string) => void
+}
+
+export default function ContentWarningForm({
+  value,
+  onChange,
+}: Props) {
+  const [open, setOpen] = useState(false)
+  const [reason, setReason] = useState('')
+
+  const currentReason = typeof value === 'string' ? value : ''
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(newOpen) => {
+        setOpen(newOpen)
+        if (newOpen) {
+          setReason(currentReason)
+        }
+      }}
+    >
+      <DialogTrigger>
+        <Toggle
+          variant="outline"
+          pressed={value !== false}
+          onPressedChange={(pressed) => {
+            onChange(pressed ? (currentReason || true) : false)
+          }}
+        >
+          <EyeOff />
+          Content Warning
+        </Toggle>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            Mark this content as warning?
+          </DialogTitle>
+        </DialogHeader>
+        <div>
+          <Label htmlFor="content-warining-reason">Reason (optional)</Label>
+          <Input
+            id="content-warining-reason"
+            placeholder="senstive, violence..."
+            value={reason}
+            onChange={event => setReason(event.target.value)}
+          />
+        </div>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setReason(currentReason)
+                setOpen(false)
+              }}
+            >
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button
+            type="submit"
+            onClick={() => {
+              onChange(reason.length > 0 ? reason : true)
+              setOpen(false)
+            }}
+          >
+            Set
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/lib/nostr/kinds/1.ts
+++ b/src/lib/nostr/kinds/1.ts
@@ -2,7 +2,7 @@ import { Schema } from 'effect'
 import { kinds } from 'nostr-tools'
 import { NostrEventSchema, TagSchema } from '../nips/01'
 import { TextNoteTagSchema } from '../nips/10'
-import { ContentWarningTagScema } from '../nips/36'
+import { ContentWarningTagSchema } from '../nips/36'
 import { createQuery } from '../query-helpers'
 
 export const TextNoteEventSchema = Schema.Struct({
@@ -11,7 +11,7 @@ export const TextNoteEventSchema = Schema.Struct({
   tags: Schema.Array(Schema.Union(
     ...TagSchema.members,
     ...TextNoteTagSchema.members,
-    ContentWarningTagScema,
+    ContentWarningTagSchema,
   )),
 })
 

--- a/src/lib/nostr/kinds/1.ts
+++ b/src/lib/nostr/kinds/1.ts
@@ -2,12 +2,17 @@ import { Schema } from 'effect'
 import { kinds } from 'nostr-tools'
 import { NostrEventSchema, TagSchema } from '../nips/01'
 import { TextNoteTagSchema } from '../nips/10'
+import { ContentWarningTagScema } from '../nips/36'
 import { createQuery } from '../query-helpers'
 
 export const TextNoteEventSchema = Schema.Struct({
   ...NostrEventSchema.fields,
   kind: Schema.Literal(kinds.ShortTextNote),
-  tags: Schema.Array(Schema.Union(...TagSchema.members, ...TextNoteTagSchema.members)),
+  tags: Schema.Array(Schema.Union(
+    ...TagSchema.members,
+    ...TextNoteTagSchema.members,
+    ContentWarningTagScema,
+  )),
 })
 
 export const TextNoteQuery = createQuery({

--- a/src/lib/nostr/nips/36.ts
+++ b/src/lib/nostr/nips/36.ts
@@ -1,0 +1,6 @@
+import { Schema } from 'effect'
+
+export const ContentWarningTagScema = Schema.Tuple(
+  Schema.Literal('content-warning'),
+  Schema.optionalElement(Schema.String),
+)

--- a/src/lib/nostr/nips/36.ts
+++ b/src/lib/nostr/nips/36.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'effect'
 
-export const ContentWarningTagScema = Schema.Tuple(
+export const ContentWarningTagSchema = Schema.Tuple(
   Schema.Literal('content-warning'),
   Schema.optionalElement(Schema.String),
 )

--- a/src/routes/(app)/home.tsx
+++ b/src/routes/(app)/home.tsx
@@ -1,4 +1,4 @@
-import TextNoteForm from '@/components/text-note/TextNoteForm'
+import TextNoteForm from '@/components/text-note/form/TextNoteForm'
 import TimeLine from '@/components/timeline/TimeLine'
 import { FollowListQuery } from '@/lib/nostr/kinds/3'
 

--- a/src/shadcn-ui/components/ui/dialog.tsx
+++ b/src/shadcn-ui/components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/shadcn-ui/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/shadcn-ui/components/ui/toggle.tsx
+++ b/src/shadcn-ui/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+import * as React from "react"
+import * as TogglePrimitive from "@radix-ui/react-toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/shadcn-ui/utils"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 px-2 min-w-9",
+        sm: "h-8 px-1.5 min-w-8",
+        lg: "h-10 px-2.5 min-w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }


### PR DESCRIPTION
fix #1140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for content warnings on notes, allowing users to hide or reveal note content with an optional reason.
  * Introduced a toggle and dialog interface for adding content warnings when creating notes.
  * Added styled dialog and toggle UI components for improved user interaction.

* **Enhancements**
  * Notes with content warnings now display a placeholder and "Show" button until revealed.
  * Users can specify a reason for content warnings when composing notes.

* **Chores**
  * Updated dependencies to include `@radix-ui/react-toggle`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->