### PR TITLE
fix(schema): allow null values for lud06 and lud16 in LightningMetada…

### DIFF
--- a/src/lib/nostr/hooks/use-zap.ts
+++ b/src/lib/nostr/hooks/use-zap.ts
@@ -6,7 +6,7 @@ import { LnurlPayInvoiceResponseSchema } from '../luds/06'
 import { getLightningLnurl, LnurlPayResponseWithNIP57Schema } from '../nips/57'
 import { signEvent } from '../utils/sign-event'
 
-export function useZap(metadata: { lud06?: string, lud16?: string }) {
+export function useZap(metadata: { lud06?: string | null, lud16?: string | null }) {
   const lnurl = useMemo(() => getLightningLnurl(metadata), [metadata])
 
   const query = useQuery({

--- a/src/lib/nostr/nips/57.ts
+++ b/src/lib/nostr/nips/57.ts
@@ -13,8 +13,8 @@ export const LnurlPayResponseWithNIP57Schema = Schema.extend(
 )
 
 export const LightningMetadataSchema = Schema.Struct({
-  lud06: Schema.String,
-  lud16: Schema.String,
+  lud06: Schema.NullOr(Schema.String),
+  lud16: Schema.NullOr(Schema.String),
 })
 
 function decodeLnurl(lnurl: string): string | undefined {

--- a/src/lib/nostr/nips/57.ts
+++ b/src/lib/nostr/nips/57.ts
@@ -28,8 +28,8 @@ function decodeLnurl(lnurl: string): string | undefined {
 }
 
 export function getLightningLnurl(metadata: {
-  lud06?: string
-  lud16?: string
+  lud06?: string | null
+  lud16?: string | null
 }): URL | undefined {
   if (metadata.lud16) {
     const [username, domain] = metadata.lud16.split('@')


### PR DESCRIPTION
…taSchema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility by allowing certain fields related to lightning addresses to accept null values in addition to strings. This enhances robustness when handling incomplete or missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->