### PR TITLE
chore: add Rollup visualizer plugin for bundle analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# rollup-plugin-visualizer
+stats.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "eslint-plugin-zod": "3.5.1",
         "knip": "6.2.0",
         "lefthook": "2.1.4",
+        "rollup-plugin-visualizer": "^7.0.1",
         "semantic-release": "25.0.3",
         "tw-animate-css": "1.4.0",
         "typescript": "5.9.3",
@@ -17433,6 +17434,50 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
       "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
       "license": "MIT"
+    },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
+      "integrity": "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^11.0.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/router": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "VITE_APP_VERSION=$(git tag --sort=-v:refname | head -n 1) vite",
     "build": "git fetch --tags && tsc -b && VITE_APP_VERSION=$(git tag --sort=-v:refname | head -n 1) vite build",
+    "analyze": "vite build --mode analyze",
     "lint": "eslint .",
     "preview": "vite preview",
     "lint:fix": "eslint --fix .",
@@ -70,6 +71,7 @@
     "eslint-plugin-zod": "3.5.1",
     "knip": "6.2.0",
     "lefthook": "2.1.4",
+    "rollup-plugin-visualizer": "^7.0.1",
     "semantic-release": "25.0.3",
     "tw-animate-css": "1.4.0",
     "typescript": "5.9.3",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,10 +4,11 @@ import tailwindcss from '@tailwindcss/vite'
 import { devtools } from '@tanstack/devtools-vite'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
 import react, { reactCompilerPreset } from '@vitejs/plugin-react'
+import { visualizer } from 'rollup-plugin-visualizer'
 import { defineConfig } from 'vite'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   resolve: {
     tsconfigPaths: true,
   },
@@ -35,5 +36,11 @@ export default defineConfig({
       presets: [reactCompilerPreset()],
     }),
     tailwindcss(),
+    mode === 'analyze' && visualizer({
+      open: true,
+      template: 'treemap',
+      gzipSize: true,
+      brotliSize: true,
+    }),
   ],
-})
+}))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a bundle analysis mode that generates interactive visualizations of build composition, size distribution, and compression metrics when invoked.
  * Analysis tooling is enabled only in the dedicated analysis run to avoid affecting normal builds.
  * Build artifact for the analyzer is ignored from version control to keep the repo clean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->